### PR TITLE
Add config setting for connecting to TFS servers that only support TLS 1.2

### DIFF
--- a/TeamProjectManager.Shell/App.config
+++ b/TeamProjectManager.Shell/App.config
@@ -28,6 +28,11 @@
     -->
     <add key="DiffToolCommand" value="" />
     <add key="DiffToolArguments" value="" />
+    <!--
+    Set to space-delimited value(s) from the SecurityProtocolType enum to control the TLS version(s) used
+    for connecting to TFS (https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype) 
+    -->
+    <add key="TlsVersions" value="Tls12"/>
   </appSettings>
   <system.diagnostics>
     <sources>


### PR DESCRIPTION
Hello and thanks for making this open source!

I ran into the same issue #29 as @jonnydatester and saw his pull request #30. I've made changes per @jelledruyts's comment to get this talking to TFS servers over TLS 1.2.

Let me know if you have any questions and thanks for making this! It has been handy at my organization already.